### PR TITLE
Misleading description of Level column in AppServiceConsoleLogs.

### DIFF
--- a/azure-monitor-ref/tables/appserviceconsolelogs.md
+++ b/azure-monitor-ref/tables/appserviceconsolelogs.md
@@ -33,7 +33,7 @@ ms.date: 8/4/2022
 | --- | --- | --- |
 | ContainerId | string | Application container id |
 | Host | string | Host where the application is running |
-| Level | string | Verbosity level of log |
+| Level | string | Standard output as Informational or standard error output as Error |
 | OperationName | string | The name of the operation represented by this event. |
 | _ResourceId | string | A unique identifier for the resource that the record is associated with |
 | ResultDescription | string | Log message description |


### PR DESCRIPTION
For the App Service, standard output and standard error output can be obtained from AppServiceConsoleLogs. These logs are output as Standard Output = Informational level and Standard Error Output = Error level. For standard output, all output is at the Informational level, regardless of the log level at which it is output.

```cs
_logger.Log(LogLevel.Information, "Information level Log");
_logger.Log(LogLevel.Warning, "Warning level Log");
_logger.Log(LogLevel.Error, "Error level Log");
_logger.Log(LogLevel.Critical, "Critical level Log");

Console.WriteLine("Hello, StdOut!");
Console.Error.WriteLine("Hello, StdErr!");
```

![image](https://user-images.githubusercontent.com/49851726/185036548-29f081c6-9aa7-4859-93b0-83a333eaf787.png)

In the Azure Monitor reference page, the description of the Level column for AppServiceConsoleLogs is misleading, we think, because it is perceived as referring to the log level of standard output. In fact, AppServiceConsoleLogs Level is supposed to have only two types of output: standard output or standard error output.

> https://docs.microsoft.com/en-us/azure/azure-monitor/reference/tables/appserviceconsolelogs#columns
> 
> ![image](https://user-images.githubusercontent.com/49851726/185035490-a18be0c1-342f-450a-95d7-5e1b5ca91326.png)

I appreciate the opportunity to discuss the description of the Level column in the above reference.
Regards,