### PR TITLE
Updated the Level column description

### DIFF
--- a/azure-monitor-ref/tables/includes/appserviceconsolelogs-include.md
+++ b/azure-monitor-ref/tables/includes/appserviceconsolelogs-include.md
@@ -15,7 +15,7 @@ ms.custom: AppServiceConsoleLogs
 | ContainerId | string | Application container id |
 | Host | string | Host where the application is running |
 | _IsBillable | string | Specifies whether ingesting the data is billable. When _IsBillable is `false` ingestion isn't billed to your Azure account |
-| Level | string | Verbosity level of log |
+| Level | string | Verbosity level of log. If the record comes from `STDERR`, the level will be `Error`; if it comes from `STDOUT`, it will be `Informational`. |
 | OperationName | string | The name of the operation represented by this event. |
 | _ResourceId | string | A unique identifier for the resource that the record is associated with |
 | ResultDescription | string | Log message description |


### PR DESCRIPTION
The `AppServiceConsoleLogs` table is populated with logs originating from Microsoft Azure App Service Web Apps.
These Web Apps can output logs to `STDOUT` or `STDERR` and this will determine if the log Level on the `AppServiceConsoleLogs` will be either `Informational` or `Error`, respectively.

Added details on how the Level column is determined based on the source of the logs.